### PR TITLE
Change block allocation

### DIFF
--- a/libmapvxl.c
+++ b/libmapvxl.c
@@ -9,45 +9,45 @@ void mapvxlCreate(MapVxl *map, int maxX, int maxY, int maxZ) {
    map->MAP_X_MAX = maxX;
    map->MAP_Y_MAX = maxY;
    map->MAP_Z_MAX = maxZ;
-   map->blocks = calloc((size_t)map->MAP_X_MAX, sizeof(unsigned char**));
-   map->color = calloc((size_t)map->MAP_X_MAX, sizeof(unsigned int**));
-   for (unsigned short x = 0; x < map->MAP_X_MAX; ++x) {
-      map->blocks[x] = calloc((size_t)(map->MAP_Y_MAX), sizeof(unsigned char*));
-      map->color[x] = calloc((size_t)(map->MAP_Y_MAX), sizeof(unsigned int*));
-      for (unsigned short y = 0; y < map->MAP_Y_MAX; ++y) {
-         map->blocks[x][y] = calloc((size_t)map->MAP_Z_MAX, sizeof(unsigned char));
-         map->color[x][y] = calloc((size_t)map->MAP_Z_MAX, sizeof(unsigned int));
-      }
+   
+   unsigned int maxXY = maxX * maxY;
+   unsigned int maxXYZ = maxX * maxY * maxZ;
+
+   map->memory_blocks_pp = (Block***)calloc(maxX, sizeof(Block**));
+   map->memory_blocks_p = (Block**)calloc(maxXY, sizeof(Block*));
+   map->memory_blocks = (Block*)calloc(maxXYZ, sizeof(Block));
+
+   for (unsigned short i = 0; i < maxX; ++i) {
+      map->memory_blocks_pp[i] = map->memory_blocks_p + (i * maxY);
    }
+
+   for (unsigned int i = 0; i < maxXY; ++i) {
+      map->memory_blocks_p[i] = map->memory_blocks + (i * maxZ);
+   }
+
+   map->blocks = map->memory_blocks_pp;
 }
 
 void mapvxlFree(MapVxl *map) {
-   for (unsigned short i = 0; i < map->MAP_Y_MAX; ++i) {
-      for (unsigned short j = 0; j < map->MAP_X_MAX; ++j) {
-         free(map->blocks[i][j]);
-         free(map->color[i][j]);
-      }
-      free(map->blocks[i]);
-      free(map->color[i]);
-   }
-   free(map->blocks);
-   free(map->color);
+   free(map->memory_blocks_pp);
+   free(map->memory_blocks_p);
+   free(map->memory_blocks);
 }
 
-static void setBlock(MapVxl *map, int x, int y, int z, int t) {
+static void unsetBlock(MapVxl *map, int x, int y, int z) {
    assert(z >= 0 && z < map->MAP_Z_MAX);
-   map->blocks[x][y][z] = t;
+   map->blocks[x][y][z].data &= ~0x01; 
 }
 
 void mapvxlSetColor(MapVxl *map, int x, int y, int z, unsigned int c) {
    assert(z >= 0 && z < map->MAP_Z_MAX);
-   map->color[x][y][z] = c;
-   map->blocks[x][y][z] = 1;
+   Block* block = &map->blocks[x][y][z];
+   block->raw = 0x01000000 | (c & 0x00FFFFFF); // Set visible and copy RGB from ARGB
 }
 
 unsigned char mapvxlFindTopBlock(MapVxl *map, int x, int y) {
    for (int z = 0; z <= 63; ++z) {
-      if (map->blocks[x][y][z] == 1) {
+      if (map->blocks[x][y][z].data & 0x01) {
          return z;
       }
    }
@@ -56,11 +56,11 @@ unsigned char mapvxlFindTopBlock(MapVxl *map, int x, int y) {
 
 void mapvxlLoadVXL(MapVxl *map, unsigned char *v) {
     int x,y,z;
+    const unsigned int BLOCK_CLEAR = 0x01000000 | (DEFAULT_COLOR & 0xFF000000);
     for (y=0; y < map->MAP_Y_MAX; ++y) {
         for (x=0; x < map->MAP_X_MAX; ++x) {
             for (z=0; z < map->MAP_Z_MAX; ++z) {
-                setBlock(map, x,y,z,1);
-                mapvxlSetColor(map, x,y,z, DEFAULT_COLOR);
+               map->blocks[x][y][z].raw = BLOCK_CLEAR;
             }
             z = 0;
             while(1) {
@@ -75,7 +75,7 @@ void mapvxlLoadVXL(MapVxl *map, unsigned char *v) {
                 int len_bottom;
 
                 for(i=z; i < top_color_start; i++)
-                    setBlock(map, x,y,i,0);
+                    unsetBlock(map, x, y, i);
 
                 color = (unsigned int *) (v+4);
                 for(z=top_color_start; z <= top_color_end; z++)
@@ -108,25 +108,33 @@ void mapvxlLoadVXL(MapVxl *map, unsigned char *v) {
 }
 
 unsigned char mapvxlIsSurface(MapVxl *map, int x, int y, int z) {
-   if (map->blocks[x][y][z]==0) return 0;
-   if (z == 0) return 1;
-   if (x   >   0 && map->blocks[x-1][y][z]==0) return 1;
-   if (x+1 < map->MAP_X_MAX && map->blocks[x+1][y][z]==0) return 1;
-   if (y   >   0 && map->blocks[x][y-1][z]==0) return 1;
-   if (y+1 < map->MAP_Y_MAX && map->blocks[x][y+1][z]==0) return 1;
-   if (z   >   0 && map->blocks[x][y][z-1]==0) return 1;
-   if (z+1 <  map->MAP_Z_MAX && map->blocks[x][y][z+1]==0) return 1;
+   if (!(map->blocks[x][y][z].data & 0x01))
+      return 0;
+   if (z == 0)
+      return 1;
+   if (x > 0 && !(map->blocks[x - 1][y][z].data & 0x01))
+      return 1;
+   if (x + 1 < map->MAP_X_MAX && !(map->blocks[x + 1][y][z].data & 0x01))
+      return 1;
+   if (y > 0 && !(map->blocks[x][y - 1][z].data & 0x01))
+      return 1;
+   if (y + 1 < map->MAP_Y_MAX && !(map->blocks[x][y + 1][z].data & 0x01))
+      return 1;
+   if (z > 0 && !(map->blocks[x][y][z - 1].data & 0x01))
+      return 1;
+   if (z + 1 < map->MAP_Z_MAX && !(map->blocks[x][y][z + 1].data & 0x01))
+      return 1;
    return 0;
 }
 
-static void mapvxlWriteColor(unsigned char **mapOut, unsigned int color) {
+static void mapvxlWriteColor(unsigned char **mapOut, Block* block) {
    // assume color is ARGB native, but endianness is unknown
 
    // file format endianness is ARGB little endian, i.e. B,G,R,A
-   (*mapOut)[0] = (color >> 0);
-   (*mapOut)[1] = (color >> 8);
-   (*mapOut)[2] = (color >> 16);
-   (*mapOut)[3] = (color >> 24);
+   (*mapOut)[0] = block->b;
+   (*mapOut)[1] = block->g;
+   (*mapOut)[2] = block->r;
+   (*mapOut)[3] = 0xFF;
    *mapOut += 4;
 }
 
@@ -157,7 +165,7 @@ size_t mapvxlWriteMap(MapVxl *map, unsigned char *mapOut) {
 
             // find the air region
             air_start = k;
-            while (k < map->MAP_Z_MAX && !map->blocks[i][j][k])
+            while (k < map->MAP_Z_MAX && !map->blocks[i][j][k].data)
                ++k;
 
             // find the top region
@@ -167,7 +175,7 @@ size_t mapvxlWriteMap(MapVxl *map, unsigned char *mapOut) {
             top_colors_end = k;
 
             // now skip past the solid voxels
-            while (k < map->MAP_Z_MAX && map->blocks[i][j][k] && !mapvxlIsSurface(map,i,j,k))
+            while (k < map->MAP_Z_MAX && map->blocks[i][j][k].data && !mapvxlIsSurface(map,i,j,k))
                ++k;
 
             // at the end of the solid voxels, we have colored voxels.
@@ -213,10 +221,10 @@ size_t mapvxlWriteMap(MapVxl *map, unsigned char *mapOut) {
             mapOut++;
 
             for (z=0; z < top_colors_len; ++z) {
-               mapvxlWriteColor(&mapOut, map->color[i][j][top_colors_start + z]);
+               mapvxlWriteColor(&mapOut, &map->blocks[i][j][top_colors_start + z]);
             }
             for (z=0; z < bottom_colors_len; ++z) {
-               mapvxlWriteColor(&mapOut, map->color[i][j][bottom_colors_start + z]);
+               mapvxlWriteColor(&mapOut, &map->blocks[i][j][bottom_colors_start + z]);
             }
          }  
       }
@@ -225,21 +233,18 @@ size_t mapvxlWriteMap(MapVxl *map, unsigned char *mapOut) {
 }
 
 unsigned int mapvxlGetColor(MapVxl *map, int x, int y, int z) {
-    if (map->blocks[x][y][z] == 0) {
-        return DEFAULT_COLOR;
-    }
-    return map->color[x][y][z];
+   Block* block = &map->blocks[x][y][z];
+   if (block->data == 0) {
+      return DEFAULT_COLOR;
+   }
+   return block->raw | 0xFF000000;
 }
 
 void mapvxlSetAir(MapVxl *map, int x, int y, int z) {
-    map->blocks[x][y][z] = 0;
-    map->color[x][y][z] = DEFAULT_COLOR;
+   Block* block = &map->blocks[x][y][z];
+   block->raw = 0x00FFFFFF & DEFAULT_COLOR;
 }
 
 unsigned char mapvxlIsSolid(MapVxl *map, int x, int y, int z) {
-    unsigned char ret = map->blocks[x][y][z];
-    if (ret > 1) {
-       return 1;
-    }
-    return ret;
+   return map->blocks[x][y][z].data & 0x01;
 }

--- a/libmapvxl.h
+++ b/libmapvxl.h
@@ -5,12 +5,29 @@
 
 #define DEFAULT_COLOR 0xFF674028
 
+typedef union {
+  struct {
+    unsigned char b;
+    unsigned char g;
+    unsigned char r;
+    unsigned char data;
+  };
+  unsigned int raw;
+} Block;
+
+_Static_assert(sizeof(Block) == 4, "struct Block has invalid size");
+
 typedef struct {
-	unsigned short MAP_X_MAX;
-	unsigned short MAP_Y_MAX;
-	unsigned short MAP_Z_MAX;
-	unsigned char ***blocks;
-	unsigned int ***color;
+  unsigned short MAP_X_MAX;
+  unsigned short MAP_Y_MAX;
+  unsigned short MAP_Z_MAX;
+
+  Block ***blocks;
+
+  // flat buffers
+  Block ***memory_blocks_pp;
+  Block **memory_blocks_p;
+  Block *memory_blocks;
 } MapVxl;
 
 void mapvxlCreate(MapVxl *map, int maxX, int maxY, int maxZ);


### PR DESCRIPTION
Change block allocation from recursive to allocating 3 buffers
and combine data and color into one struct.

Block structure (little endianness):
- `b,g,r`: color component
- `data`: block state (currently only one state - air/solid - least significant bit)
- `raw`: entire structure as 32-bit integer

Block structure may not work on big-endian architecture.

Allocation:
- double pointer array
- pointer array
- block array

There is no alpha channel (transparency).
Use bit operators to set colors through `raw`
without modifying value of `data`.